### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/amitkurud/portfolio/security/code-scanning/2](https://github.com/amitkurud/portfolio/security/code-scanning/2)

To fix this problem, explicitly declare a `permissions` block at the root of the workflow (`.github/workflows/node.js.yml`). This block should grant only the minimum required permissions for the workflow steps shown. Since the workflow only checks out code, installs dependencies, and runs builds/tests, it needs only `contents: read` access. Insert the following at the top level of the file, after the `name:` field and before the `on:` trigger.

- Edit `.github/workflows/node.js.yml`
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name:` field (line 4).

No additional libraries, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
