### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,8 @@ jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/amitkurud/portfolio/security/code-scanning/1](https://github.com/amitkurud/portfolio/security/code-scanning/1)

To fix the issue, we will add an explicit `permissions` block to the workflow. Since this workflow mainly requires access to repository contents for checking out the code, the `contents: read` permission should suffice. We'll apply the `permissions` block at the job level (`push_to_registry`) to ensure it only affects this job. 

Additionally, if in the future other jobs are added to the workflow, they can define their own permissions as needed without inheriting from this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
